### PR TITLE
fix: update database configuration to ensure local and external setti…

### DIFF
--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="PROJECT_FILES" />
+    <option name="description" value="" />
+    <option name="applicationTheme" value="default" />
+    <option name="iconsTheme" value="default" />
+    <option name="button1Title" value="" />
+    <option name="button1Url" value="" />
+    <option name="button2Title" value="" />
+    <option name="button2Url" value="" />
+    <option name="customApplicationId" value="" />
+  </component>
+</project>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="48eb1ba5:1950e2e7aa6:-7ffe" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,10 +3,6 @@
   <component name="ComposerSettings">
     <execution />
   </component>
-  <component name="DiscordProjectSettings">
-    <option name="show" value="ASK" />
-    <option name="description" value="" />
-  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />

--- a/src/main/kotlin/dev/slne/surf/database/DatabaseProvider.kt
+++ b/src/main/kotlin/dev/slne/surf/database/DatabaseProvider.kt
@@ -44,7 +44,10 @@ class DatabaseProvider(configDirectory: Path, private val storageDirectory: Path
             }
 
             else -> {
-                log.atWarning().log("Unknown storage method '%s'. Using local storage...", config.storageMethod)
+                log.atWarning().log(
+                "Unknown storage method '%s'. Using local storage...",
+                config.storageMethod
+                )
                 connectLocal()
             }
         }

--- a/src/main/kotlin/dev/slne/surf/database/DatabaseProvider.kt
+++ b/src/main/kotlin/dev/slne/surf/database/DatabaseProvider.kt
@@ -21,7 +21,10 @@ class DatabaseProvider(configDirectory: Path, private val storageDirectory: Path
     private lateinit var connection: Database
 
     init {
-        surfConfigApi.createSpongeYmlConfig<DatabaseConfig>(configDirectory, "database-config.yml")
+        surfConfigApi.createSpongeYmlConfig<DatabaseConfig>(
+            configDirectory,
+            "database-config.yml"
+        )
     }
 
     private val config get() = surfConfigApi.getSpongeConfig<DatabaseConfig>()

--- a/src/main/kotlin/dev/slne/surf/database/DatabaseProvider.kt
+++ b/src/main/kotlin/dev/slne/surf/database/DatabaseProvider.kt
@@ -21,10 +21,7 @@ class DatabaseProvider(configDirectory: Path, private val storageDirectory: Path
     private lateinit var connection: Database
 
     init {
-        surfConfigApi.createSpongeYmlConfig<DatabaseConfig>(
-            configDirectory,
-            "database-config.yml"
-        )
+        surfConfigApi.createSpongeYmlConfig<DatabaseConfig>(configDirectory, "database-config.yml")
     }
 
     private val config get() = surfConfigApi.getSpongeConfig<DatabaseConfig>()
@@ -44,11 +41,7 @@ class DatabaseProvider(configDirectory: Path, private val storageDirectory: Path
             }
 
             else -> {
-                log.atWarning().log(
-                    "Unknown storage method '%s'. Using local storage...",
-                    config.storageMethod
-                )
-
+                log.atWarning().log("Unknown storage method '%s'. Using local storage...", config.storageMethod)
                 connectLocal()
             }
         }
@@ -56,7 +49,6 @@ class DatabaseProvider(configDirectory: Path, private val storageDirectory: Path
 
     private fun connectLocal() {
         val internal = config.local
-            ?: error("Local database config is null. Cannot connect to internal database.")
         val fileName = internal.fileName ?: "storage.db"
 
         Class.forName("org.sqlite.JDBC")
@@ -83,8 +75,6 @@ class DatabaseProvider(configDirectory: Path, private val storageDirectory: Path
 
     private fun connectExternal() {
         val external = config.external
-            ?: error("External database config is null. Cannot connect to external database.")
-
         val hikari = config.hikari
 
         connectUsingHikari(

--- a/src/main/kotlin/dev/slne/surf/database/DatabaseProvider.kt
+++ b/src/main/kotlin/dev/slne/surf/database/DatabaseProvider.kt
@@ -45,8 +45,8 @@ class DatabaseProvider(configDirectory: Path, private val storageDirectory: Path
 
             else -> {
                 log.atWarning().log(
-                "Unknown storage method '%s'. Using local storage...",
-                config.storageMethod
+                    "Unknown storage method '%s'. Using local storage...",
+                    config.storageMethod
                 )
                 connectLocal()
             }

--- a/src/main/kotlin/dev/slne/surf/database/config/DatabaseConfig.kt
+++ b/src/main/kotlin/dev/slne/surf/database/config/DatabaseConfig.kt
@@ -3,11 +3,11 @@ package dev.slne.surf.database.config
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
 
 @ConfigSerializable
-data class DatabaseConfig(
+data class DatabaseConfig (
     val storageMethod: String = "local",
 
-    val local: LocalDatabaseConfig? = null,
-    val external: ExternalDatabaseConfig? = null,
+    val local: LocalDatabaseConfig = LocalDatabaseConfig(),
+    val external: ExternalDatabaseConfig = ExternalDatabaseConfig(),
 
     val hikari: DatabaseHikariConfig = DatabaseHikariConfig()
 )


### PR DESCRIPTION
…ngs are initialized

This pull request includes updates to project configuration files and refactors the `DatabaseProvider` class to simplify the code and improve type safety. The most important changes are grouped into configuration updates and database-related refactoring.

### Configuration Updates:
* Added `.idea/discord.xml` and `.idea/material_theme_project_new.xml` to configure project-specific settings for Discord integration and Material Theme. (`[[1]](diffhunk://#diff-036da77e0e4b2f4e042049d9b20f5cfc4a347bc1e01391bd3bf3bc8ae4601768R1-R14)`, `[[2]](diffhunk://#diff-36c738133cb28c8c4567d8b1825298a23197d472679d924ddb81e1e18641c707R1-R12)`)
* Removed `DiscordProjectSettings` from `.idea/misc.xml` as it is now handled in the new `.idea/discord.xml` file. (`[.idea/misc.xmlL6-L9](diffhunk://#diff-7ea1cd7bd5d16299a0abd33128e8d0a8bc04146f6b00c07bcd3cc0aad813c229L6-L9)`)

### Database-Related Refactoring:
* Simplified the `surfConfigApi.createSpongeYmlConfig` call in `DatabaseProvider` by reducing it to a single line. (`[src/main/kotlin/dev/slne/surf/database/DatabaseProvider.ktL24-R24](diffhunk://#diff-3c4aa355e18d70c16f2f2d296f4e454ba02d266a694d42e65adbad1c39d6b4a2L24-R24)`)
* Refactored logging for unknown storage methods and removed unnecessary null checks for local and external database configurations. (`[[1]](diffhunk://#diff-3c4aa355e18d70c16f2f2d296f4e454ba02d266a694d42e65adbad1c39d6b4a2L47-L59)`, `[[2]](diffhunk://#diff-3c4aa355e18d70c16f2f2d296f4e454ba02d266a694d42e65adbad1c39d6b4a2L86-L87)`)
* Updated `DatabaseConfig` to use non-nullable default values for `local` and `external` configurations, improving type safety. (`[src/main/kotlin/dev/slne/surf/database/config/DatabaseConfig.ktL9-R10](diffhunk://#diff-b168a90e488414b3c362e8c917bddf3a9e88f958de704e847a1ba200e933966fL9-R10)`)